### PR TITLE
feat: search components + direct upload without gist

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -47,6 +47,37 @@ CREATE TABLE IF NOT EXISTS abuse_reports (
 CREATE INDEX idx_abuse_reports_gist_id ON abuse_reports(gist_id);
 CREATE INDEX idx_abuse_reports_status ON abuse_reports(status);
 
+-- Direct uploads
+ALTER TABLE stored_gists ADD COLUMN source TEXT DEFAULT 'gist';
+ALTER TABLE stored_gists ADD COLUMN uploaded_by TEXT;
+
+-- Full-text search
+CREATE VIRTUAL TABLE IF NOT EXISTS component_search USING fts5(
+    share_id,
+    filename,
+    description,
+    content='stored_gists',
+    content_rowid='id'
+);
+
+-- Triggers to keep FTS in sync
+CREATE TRIGGER IF NOT EXISTS stored_gists_ai AFTER INSERT ON stored_gists BEGIN
+    INSERT INTO component_search(rowid, share_id, filename, description)
+    VALUES (new.id, new.share_id, new.filename, new.description);
+END;
+
+CREATE TRIGGER IF NOT EXISTS stored_gists_ad AFTER DELETE ON stored_gists BEGIN
+    INSERT INTO component_search(component_search, rowid, share_id, filename, description)
+    VALUES ('delete', old.id, old.share_id, old.filename, old.description);
+END;
+
+CREATE TRIGGER IF NOT EXISTS stored_gists_au AFTER UPDATE ON stored_gists BEGIN
+    INSERT INTO component_search(component_search, rowid, share_id, filename, description)
+    VALUES ('delete', old.id, old.share_id, old.filename, old.description);
+    INSERT INTO component_search(rowid, share_id, filename, description)
+    VALUES (new.id, new.share_id, new.filename, new.description);
+END;
+
 -- Rate Limiting
 CREATE TABLE IF NOT EXISTS rate_limits (
     ip TEXT NOT NULL,

--- a/src/App.css
+++ b/src/App.css
@@ -1597,3 +1597,143 @@ footer p {
   color: white;
   border-color: #4f46e5;
 }
+
+/* Search component */
+.component-search {
+  background: var(--bg-card, white);
+  padding: 2rem;
+  border-radius: 16px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
+  border: 1px solid var(--border-color, #e2e8f0);
+  margin-bottom: 2rem;
+  text-align: center;
+}
+
+.component-search h3 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+
+.search-input {
+  width: 100%;
+  max-width: 500px;
+  padding: 0.75rem 1.25rem;
+  border: 2px solid var(--border-color, #e2e8f0);
+  border-radius: 12px;
+  font-size: 1rem;
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+.search-input:focus {
+  border-color: #4f46e5;
+  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.1);
+}
+
+.search-results {
+  margin-top: 1rem;
+  text-align: left;
+  max-width: 500px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.search-result {
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--border-color, #e2e8f0);
+  border-radius: 8px;
+  margin-bottom: 0.5rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.search-result:hover {
+  border-color: #4f46e5;
+  background: rgba(79, 70, 229, 0.05);
+}
+
+.search-filename {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.search-desc {
+  font-size: 0.85rem;
+  color: var(--text-secondary, #64748b);
+}
+
+.search-meta {
+  font-size: 0.75rem;
+  color: var(--text-secondary, #94a3b8);
+}
+
+.search-status {
+  margin-top: 0.75rem;
+  font-size: 0.9rem;
+  color: var(--text-secondary, #64748b);
+}
+
+/* Deploy button */
+.deploy-actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.deploy-btn {
+  padding: 0.875rem 2.5rem;
+  background: linear-gradient(135deg, #059669, #10b981);
+  color: white;
+  border: none;
+  border-radius: 12px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s;
+  text-decoration: none;
+  display: inline-block;
+}
+
+.deploy-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px rgba(5, 150, 105, 0.3);
+}
+
+.deploy-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.deploy-btn.auth-required {
+  background: #24292e;
+}
+
+.deploy-result {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  justify-content: center;
+  padding: 1rem;
+  background: #f0fdf4;
+  border-radius: 12px;
+  border: 2px solid #bbf7d0;
+  margin-top: 1rem;
+}
+
+.deploy-result span {
+  font-weight: 700;
+  color: #16a34a;
+}
+
+.deploy-link {
+  color: #4f46e5;
+  font-weight: 500;
+  font-family: monospace;
+  font-size: 0.9rem;
+}

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -3,6 +3,79 @@ import { ThemeToggle } from './ThemeToggle'
 
 const LiveDemo = lazy(() => import('./LiveDemo').then(m => ({ default: m.LiveDemo })))
 
+interface SearchResult {
+  share_id: string
+  filename: string
+  description: string | null
+  source: string | null
+  uploaded_by: string | null
+  view_count: number | null
+}
+
+function ComponentSearch() {
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<SearchResult[]>([])
+  const [searching, setSearching] = useState(false)
+  const debounceRef = useState<ReturnType<typeof setTimeout> | null>(null)
+
+  const handleSearch = (q: string) => {
+    setQuery(q)
+    if (debounceRef[0]) clearTimeout(debounceRef[0])
+    if (q.length < 2) {
+      setResults([])
+      return
+    }
+    debounceRef[0] = setTimeout(async () => {
+      setSearching(true)
+      try {
+        const res = await fetch(`/api/search?q=${encodeURIComponent(q)}`)
+        if (res.ok) {
+          const data = await res.json() as SearchResult[]
+          setResults(data)
+        }
+      } catch { /* silent */ }
+      finally { setSearching(false) }
+    }, 300)
+  }
+
+  const handleResultClick = (shareId: string) => {
+    window.history.pushState(null, '', `/share/${shareId}`)
+    window.dispatchEvent(new PopStateEvent('popstate'))
+  }
+
+  return (
+    <div className="component-search">
+      <h3>Search Components</h3>
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => handleSearch(e.target.value)}
+        placeholder="Search by name or description..."
+        className="search-input"
+        aria-label="Search components"
+      />
+      {searching && <div className="search-status">Searching...</div>}
+      {results.length > 0 && (
+        <div className="search-results">
+          {results.map((r) => (
+            <div key={r.share_id} className="search-result" onClick={() => handleResultClick(r.share_id)}>
+              <span className="search-filename">{r.filename}</span>
+              {r.description && <span className="search-desc">{r.description}</span>}
+              <span className="search-meta">
+                {r.uploaded_by ? `by ${r.uploaded_by}` : ''}
+                {r.view_count ? ` · ${r.view_count} views` : ''}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+      {query.length >= 2 && !searching && results.length === 0 && (
+        <div className="search-status">No components found</div>
+      )}
+    </div>
+  )
+}
+
 function GistUrlInput() {
   const [url, setUrl] = useState('')
   const [error, setError] = useState('')
@@ -325,6 +398,8 @@ export function LandingPage() {
             </div>
           </details>
         </section>
+
+        <ComponentSearch />
 
         <GistUrlInput />
 

--- a/src/components/ValidatorPage.tsx
+++ b/src/components/ValidatorPage.tsx
@@ -58,6 +58,8 @@ export function ValidatorPage() {
   const [showPreview, setShowPreview] = useState(false)
   const [previewWidth, setPreviewWidth] = useState<'100%' | '768px' | '375px'>('100%')
   const [user, setUser] = useState<GitHubUser | null>(null)
+  const [deploying, setDeploying] = useState(false)
+  const [deployResult, setDeployResult] = useState<{ shareUrl: string; shareId: string } | null>(null)
   const [authLoading, setAuthLoading] = useState(true)
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(null)
 
@@ -93,6 +95,32 @@ export function ValidatorPage() {
   const goHome = () => {
     window.history.pushState(null, '', '/')
     window.dispatchEvent(new PopStateEvent('popstate'))
+  }
+
+  const handleDeploy = async () => {
+    if (!validation?.isDeployable || !validation.componentName || !user) return
+    setDeploying(true)
+    try {
+      const response = await fetch('/api/upload', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          content: validation.processedCode || code,
+          filename: `${validation.componentName}.tsx`,
+          description: `Uploaded by ${user.login} via ReactDrop validator`,
+        }),
+      })
+      const data = await response.json() as { success?: boolean; shareUrl?: string; shareId?: string; error?: string }
+      if (data.success && data.shareUrl && data.shareId) {
+        setDeployResult({ shareUrl: data.shareUrl, shareId: data.shareId })
+      } else {
+        alert(data.error || 'Deploy failed')
+      }
+    } catch {
+      alert('Deploy failed - check your connection')
+    } finally {
+      setDeploying(false)
+    }
   }
 
   const sandpackFiles = validation?.processedCode && validation.componentName
@@ -171,13 +199,43 @@ export default function App() {
                   <div className="summary-pass" role="status">
                     ✓ Component is deployable on ReactDrop
                   </div>
-                  {!showPreview && (
-                    <button
-                      className="preview-btn"
-                      onClick={() => setShowPreview(true)}
-                    >
-                      Preview Component
-                    </button>
+                  <div className="deploy-actions">
+                    {!showPreview && (
+                      <button
+                        className="preview-btn"
+                        onClick={() => setShowPreview(true)}
+                      >
+                        Preview Component
+                      </button>
+                    )}
+                    {user && !deployResult && (
+                      <button
+                        className="deploy-btn"
+                        onClick={handleDeploy}
+                        disabled={deploying}
+                      >
+                        {deploying ? 'Deploying...' : 'Deploy to ReactDrop'}
+                      </button>
+                    )}
+                    {!user && (
+                      <a href="/api/auth/login" className="deploy-btn auth-required">
+                        Sign in to deploy
+                      </a>
+                    )}
+                  </div>
+                  {deployResult && (
+                    <div className="deploy-result">
+                      <span>Deployed!</span>
+                      <a href={deployResult.shareUrl} className="deploy-link">
+                        {deployResult.shareUrl}
+                      </a>
+                      <button
+                        className="copy-btn"
+                        onClick={() => navigator.clipboard.writeText(deployResult.shareUrl)}
+                      >
+                        📋
+                      </button>
+                    </div>
                   )}
                 </>
               ) : (

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -736,6 +736,120 @@ export default {
         }
       }
 
+      // Search components
+      if (path === "/api/search" && request.method === "GET") {
+        const query = url.searchParams.get('q');
+        if (!query || query.length < 2) {
+          return Response.json({ error: 'Query must be at least 2 characters' }, { status: 400, headers: corsHeaders });
+        }
+
+        try {
+          // Try FTS5 first, fall back to LIKE search
+          let results;
+          try {
+            results = await env.DB.prepare(`
+              SELECT s.share_id, s.filename, s.description, s.source, s.uploaded_by,
+                     a.view_count, a.first_accessed_at
+              FROM component_search cs
+              JOIN stored_gists s ON s.id = cs.rowid
+              LEFT JOIN gist_analytics a ON a.gist_id = s.original_gist_id AND a.filename = s.filename
+              WHERE component_search MATCH ?
+              ORDER BY rank
+              LIMIT 20
+            `).bind(query).all();
+          } catch {
+            // FTS table might not exist yet, fall back to LIKE
+            results = await env.DB.prepare(`
+              SELECT s.share_id, s.filename, s.description, s.source, s.uploaded_by,
+                     a.view_count, a.first_accessed_at
+              FROM stored_gists s
+              LEFT JOIN gist_analytics a ON a.gist_id = s.original_gist_id AND a.filename = s.filename
+              WHERE s.filename LIKE ? OR s.description LIKE ?
+              ORDER BY a.view_count DESC
+              LIMIT 20
+            `).bind(`%${query}%`, `%${query}%`).all();
+          }
+
+          return Response.json(results.results, { headers: corsHeaders });
+        } catch (error) {
+          log.error('Search failed', error);
+          return Response.json({ error: 'Search failed' }, { status: 500, headers: corsHeaders });
+        }
+      }
+
+      // Direct upload (requires authentication)
+      if (path === "/api/upload" && request.method === "POST") {
+        // Verify auth cookie
+        const cookie = request.headers.get('cookie') || '';
+        const authMatch = cookie.match(/gh_user=([^;]+)/);
+        if (!authMatch) {
+          return Response.json({ error: 'Authentication required' }, { status: 401, headers: corsHeaders });
+        }
+
+        let username: string;
+        try {
+          const parts = authMatch[1].split('.');
+          if (parts.length !== 2) throw new Error('Invalid cookie');
+          const [payload, sig] = parts;
+          const expectedSig = await signCookie(payload, env.GITHUB_CLIENT_SECRET);
+          if (sig !== expectedSig) throw new Error('Invalid signature');
+          const user = JSON.parse(atob(payload));
+          username = user.login;
+        } catch {
+          return Response.json({ error: 'Invalid authentication' }, { status: 401, headers: corsHeaders });
+        }
+
+        try {
+          const body = await request.json() as { content?: string; filename?: string; description?: string };
+          const { content, filename, description } = body;
+
+          if (!content || !filename) {
+            return Response.json({ error: 'content and filename are required' }, { status: 400, headers: corsHeaders });
+          }
+
+          if (content.length > 50 * 1024) {
+            return Response.json({ error: 'Content exceeds 50KB limit' }, { status: 400, headers: corsHeaders });
+          }
+
+          if (!filename.endsWith('.tsx')) {
+            return Response.json({ error: 'Filename must end with .tsx' }, { status: 400, headers: corsHeaders });
+          }
+
+          // Generate share ID
+          let shareId = generateShareId();
+          let attempts = 0;
+          while (attempts < 10) {
+            const collision = await env.DB.prepare(
+              'SELECT share_id FROM stored_gists WHERE share_id = ?'
+            ).bind(shareId).first();
+            if (!collision) break;
+            shareId = generateShareId();
+            attempts++;
+          }
+
+          // Store as upload (no original gist ID)
+          const uploadGistId = `upload-${username}-${Date.now()}`;
+          await env.DB.prepare(`
+            INSERT INTO stored_gists (share_id, original_gist_id, filename, content, description, source, uploaded_by)
+            VALUES (?, ?, ?, ?, ?, 'upload', ?)
+          `).bind(shareId, uploadGistId, filename, content, description || '', username).run();
+
+          // Track analytics
+          await updateAnalytics(env, uploadGistId, filename, true);
+
+          log.info(`Uploaded component by ${username}: ${shareId}`);
+          return Response.json({
+            success: true,
+            shareId,
+            shareUrl: `${url.origin}/share/${shareId}`,
+            uploadedBy: username,
+          }, { headers: corsHeaders });
+        } catch (error) {
+          log.error('Upload failed', error);
+          return Response.json({ error: 'Upload failed' }, { status: 500, headers: corsHeaders });
+        }
+      }
+
       return Response.json({ error: 'API endpoint not found' }, { status: 404 });
     }
 


### PR DESCRIPTION
## Summary

### Search
- FTS5 full-text search on component names and descriptions
- `/api/search?q=query` endpoint with LIKE fallback
- Debounced search UI on landing page
- Click results to view components

### Direct Upload
- `/api/upload` POST endpoint for authenticated users
- Components stored directly in D1 (no GitHub Gist required)
- "Deploy to ReactDrop" button in validator after validation passes
- "Sign in to deploy" for unauthenticated users
- Deploy result shows shareable URL

### Schema Changes
- `stored_gists.source` column: 'gist' or 'upload'
- `stored_gists.uploaded_by` column: GitHub username
- `component_search` FTS5 virtual table with sync triggers
- **Requires DB migration** (see schema.sql for ALTER TABLE + CREATE statements)

## Test plan
- [x] 15 integration tests passing
- [x] Build succeeds
- [x] Existing gist flow unaffected

Generated with [Claude Code](https://claude.com/claude-code)